### PR TITLE
Remove latexsym dependency

### DIFF
--- a/gnuplottex.dtx
+++ b/gnuplottex.dtx
@@ -43,7 +43,7 @@
 %<package> \ProvidesPackage{gnuplottex}
 %<*package>
     [2013/11/24 v0.8 gnuplot graphs in LaTeX]
-\RequirePackage{latexsym,graphicx,moreverb,keyval,ifthen}
+\RequirePackage{graphicx,moreverb,keyval,ifthen}
 %</package>
 %
 %<*driver>


### PR DESCRIPTION
Caused an error due to too much alphabets in use with my template.
What was the purpose of it, anyway?
I don't see a direct benefit for gnuplottex, since latexsym only handles font loading respectively some symbol definitions, as far as I can see.
Short (and certainly not comprehensive) testing revealed no problems.
